### PR TITLE
Author- Pankaj Jakhar: changes in build.gradle and gradle.wrapper.proper...

### DIFF
--- a/GrocerySync-Android/build.gradle
+++ b/GrocerySync-Android/build.gradle
@@ -19,7 +19,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.8.+'
+        classpath 'com.android.tools.build:gradle:0.7.+'
     }
 }
 apply plugin: 'android'
@@ -42,28 +42,19 @@ dependencies {
     // 1) Run 'git submodule init && git submodule update' on the command line
     // 2) uncomment the next line
     // 3) uncomment the line in settings.gradle
-    // 4) comment the compile 'com.couchbase.cblite:CBLite:1.0.0-beta2' line below
+    // 4) comment the compile 'com.couchbase.cblite:CBLite:1.0.0-beta2rc1' line below
     // compile project(':CBLite')
 
-    compile 'com.couchbase.cblite:CBLite:1.0.0-beta2'
-
+    compile 'com.couchbase.cblite:CBLite:1.0.0-beta2rc1'
 }
 
 android {
-    compileSdkVersion 19
-    buildToolsVersion "19.0.0"
+    compileSdkVersion 17
+    buildToolsVersion "17.0.0"
 
     defaultConfig {
         minSdkVersion 11
-        targetSdkVersion 19
-    }
-
-    // workaround for "duplicate files during packaging of APK" issue
-    // see https://groups.google.com/d/msg/adt-dev/bl5Rc4Szpzg/wC8cylTWuIEJ
-    packagingOptions {
-        exclude 'META-INF/ASL2.0'
-        exclude 'META-INF/LICENSE'
-        exclude 'META-INF/NOTICE'
+        targetSdkVersion 16
     }
 }
 
@@ -74,4 +65,12 @@ task sourcesJar(type: Jar) {
 
 task generateJavadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
+}
+
+android {
+    packagingOptions {
+        exclude 'META-INF/ASL2.0'
+        exclude 'META-INF/LICENSE'
+        exclude 'META-INF/NOTICE'
+    }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jan 28 17:43:21 PST 2014
+#Wed Jan 29 11:35:57 IST 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.9-bin.zip


### PR DESCRIPTION
...ties file. Which is working fine on Android Studio 0.4.x version. Changes made 1. distributionUrl's value in gradle-wrapper.properties which is set to http://services.gradle.org/distributions/gradle-1.9-bin.zip now. 2. build.gradle file updated to exclude some files from android APK packaging; those files were creating conflicts in AKP building.
