### PR TITLE
Add ability to toggle wifi in grocery-sync app

### DIFF
--- a/GrocerySync-Android/build.gradle
+++ b/GrocerySync-Android/build.gradle
@@ -21,7 +21,7 @@ android {
     buildToolsVersion "22.0.1"
 
     defaultConfig {
-        minSdkVersion 9
+        minSdkVersion 11
         targetSdkVersion 22
     }
 

--- a/GrocerySync-Android/src/main/AndroidManifest.xml
+++ b/GrocerySync-Android/src/main/AndroidManifest.xml
@@ -5,8 +5,11 @@
     android:versionName="1.0" >
 
     <uses-sdk
-        android:minSdkVersion="9"
+        android:minSdkVersion="11"
         android:targetSdkVersion="19" />
+
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE"/>
 
     <application
         android:allowBackup="true"

--- a/GrocerySync-Android/src/main/java/com/couchbase/grocerysync/MainActivity.java
+++ b/GrocerySync-Android/src/main/java/com/couchbase/grocerysync/MainActivity.java
@@ -3,8 +3,10 @@ package com.couchbase.grocerysync;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.net.wifi.WifiManager;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.Menu;
@@ -329,6 +331,21 @@ public class MainActivity extends Activity implements Replication.ChangeListener
      * Add settings item to the menu
      */
     public boolean onCreateOptionsMenu(Menu menu) {
+
+        MenuItem offlineMenu = menu.add("Toggle Wifi");
+        offlineMenu.setShowAsAction(MenuItem.SHOW_AS_ACTION_ALWAYS);
+        offlineMenu.setOnMenuItemClickListener(new MenuItem.OnMenuItemClickListener() {
+                                                   @Override
+                                                   public boolean onMenuItemClick(MenuItem item) {
+                                                       WifiManager wifiManager = (WifiManager)getSystemService(Context.WIFI_SERVICE);
+                                                       boolean nextWifiState = !wifiManager.isWifiEnabled();
+                                                       wifiManager.setWifiEnabled(nextWifiState);
+                                                       String itemTitle = !nextWifiState ? "Enable Wifi" : "Disable Wifi";
+                                                       item.setTitle(itemTitle);
+                                                       return true;
+                                                   }
+                                               });
+
         menu.add(Menu.NONE, 0, 0, "Settings");
         return super.onCreateOptionsMenu(menu);
     }


### PR DESCRIPTION
@hideki I wasn't sure what branch to target this PR on, so feel free to change as you see fit. 

- This adds the ability to toggle Wifi in app.
NOTE: I had to bump the min API version to 11 to use the setShowAsAction method.

![screenshot 2016-02-03 15 49 33](https://cloud.githubusercontent.com/assets/1365736/12800970/c8218c40-ca8d-11e5-88a0-9cf0cbb0cdf8.png)
